### PR TITLE
adds interaction style to relationships

### DIFF
--- a/structurizr-kotlin/src/main/kotlin/cc/catalysts/structurizr/kotlin/StructurizrExtension.kt
+++ b/structurizr-kotlin/src/main/kotlin/cc/catalysts/structurizr/kotlin/StructurizrExtension.kt
@@ -43,17 +43,17 @@ fun SoftwareSystem.addContainer(name: String, description: String, vararg techno
     config.tags.forEach { t -> container.addTags(t) }
     config.uses.forEach({ d ->
         when (d.element) {
-            is SoftwareSystem -> container.uses(d.element, d.description, d.technology)
-            is Container -> container.uses(d.element, d.description, d.technology)
-            is Component -> container.uses(d.element, d.description, d.technology)
+            is SoftwareSystem -> container.uses(d.element, d.description, d.technology, d.interactionStyle)
+            is Container -> container.uses(d.element, d.description, d.technology, d.interactionStyle)
+            is Component -> container.uses(d.element, d.description, d.technology, d.interactionStyle)
         }
     })
     config.usedBy.forEach({ d ->
         when (d.element) {
-            is SoftwareSystem -> d.element.uses(container, d.description, d.technology)
-            is Container -> d.element.uses(container, d.description, d.technology)
-            is Component -> d.element.uses(container, d.description, d.technology)
-            is Person -> d.element.uses(container, d.description, d.technology)
+            is SoftwareSystem -> d.element.uses(container, d.description, d.technology, d.interactionStyle)
+            is Container -> d.element.uses(container, d.description, d.technology, d.interactionStyle)
+            is Component -> d.element.uses(container, d.description, d.technology, d.interactionStyle)
+            is Person -> d.element.uses(container, d.description, d.technology, d.interactionStyle)
         }
     })
     return container
@@ -68,17 +68,17 @@ fun Container.addComponent(name: String, description: String, vararg technologie
     config.tags.forEach { t -> component.addTags(t) }
     config.uses.forEach({ d ->
         when (d.element) {
-            is SoftwareSystem -> component.uses(d.element, d.description, d.technology)
-            is Container -> component.uses(d.element, d.description, d.technology)
-            is Component -> component.uses(d.element, d.description, d.technology)
+            is SoftwareSystem -> component.uses(d.element, d.description, d.technology, d.interactionStyle)
+            is Container -> component.uses(d.element, d.description, d.technology, d.interactionStyle)
+            is Component -> component.uses(d.element, d.description, d.technology, d.interactionStyle)
         }
     })
     config.usedBy.forEach({ d ->
         when (d.element) {
-            is SoftwareSystem -> d.element.uses(component, d.description, d.technology)
-            is Container -> d.element.uses(component, d.description, d.technology)
-            is Component -> d.element.uses(component, d.description, d.technology)
-            is Person -> d.element.uses(component, d.description, d.technology)
+            is SoftwareSystem -> d.element.uses(component, d.description, d.technology, d.interactionStyle)
+            is Container -> d.element.uses(component, d.description, d.technology, d.interactionStyle)
+            is Component -> d.element.uses(component, d.description, d.technology, d.interactionStyle)
+            is Person -> d.element.uses(component, d.description, d.technology, d.interactionStyle)
         }
     })
     return component
@@ -94,12 +94,12 @@ class ElementConfiguration {
         this.tags.addAll(tag)
     }
 
-    fun uses(element: Element, description: String, vararg technologies: String) {
-        this.uses.add(Dependency(element, description, concat(technologies)))
+    fun uses(element: Element, description: String, vararg technologies: String, interactionStyle: InteractionStyle? = null) {
+        this.uses.add(Dependency(element, description, concat(technologies), interactionStyle))
     }
 
-    fun usedBy(element: Element, description: String, vararg technologies: String) {
-        this.usedBy.add(Dependency(element, description, concat(technologies)))
+    fun usedBy(element: Element, description: String, vararg technologies: String, interactionStyle: InteractionStyle? = null) {
+        this.usedBy.add(Dependency(element, description, concat(technologies), interactionStyle))
     }
 
     private fun concat(values: Array<out String>): String {
@@ -107,4 +107,4 @@ class ElementConfiguration {
     }
 }
 
-data class Dependency(val element: Element, val description: String, val technology: String)
+data class Dependency(val element: Element, val description: String, val technology: String, val interactionStyle: InteractionStyle? = null)

--- a/structurizr-kotlin/src/test/kotlin/cc/catalysts/structurizr/kotlin/StructurizrExtensionTest.kt
+++ b/structurizr-kotlin/src/test/kotlin/cc/catalysts/structurizr/kotlin/StructurizrExtensionTest.kt
@@ -1,6 +1,7 @@
 package cc.catalysts.structurizr.kotlin
 
 import com.structurizr.Workspace
+import com.structurizr.model.InteractionStyle
 
 /**
  * @author Klaus Lehner, Catalysts GmbH
@@ -22,6 +23,11 @@ class StructurizrExtensionTest {
 
         val container3 = softwareSystem.addContainer("Container 3", "") {
             usedBy(container2, "", "Soap")
+        }
+
+        val container4 = softwareSystem.addContainer("Container 4", "", "Kotlin") {
+            usedBy(container3, "", "REST", interactionStyle = InteractionStyle.Synchronous)
+            uses(container1, "", "SOAP", interactionStyle = InteractionStyle.Asynchronous)
         }
     }
 }


### PR DESCRIPTION
Addresses issue #10 

Adds optional interaction style param (null by default) to `uses` and `usedBy` relationship methods. To keep from making a breaking change to the API, it comes after the technologies vararg parameter, so must be specified in passing parameters.

Added a test case for both uses and usedBy using the interactionStyle param. The existing test cases without it also serve as a test case for not passing the param, but happy to refactor this based on your feedback.

Thanks!